### PR TITLE
Project URL uses https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ def pomConfigurationFor(String pomName, String pomDescription) {
     return {
         name = pomName
         description = pomDescription
-        url = 'http://hamcrest.org/JavaHamcrest/'
+        url = 'https://hamcrest.org/JavaHamcrest/'
 
         scm {
             connection = 'scm:git:https://github.com/hamcrest/JavaHamcrest.git'


### PR DESCRIPTION
https://hamcrest.org/JavaHamcrest/ is available so the URL should use the secure site over the unencrypted one.